### PR TITLE
remove unnecessary labels and other doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ To uninstall the chart:
 | serviceMonitor.additionalLabels | Labels for serviceMonitor | `{}` |
 | serviceMonitor.annotations | Annotations for serviceMonitor | `{}` |
 | serviceMonitor.jobLabel | Job Label used for application selector | `k8s-app` |
-| serviceMonitor.endpoints | Array of endpoints to be scraped by prometheus |   - interval: 5s<br>&nbsp;&nbsp;path: /actuator/prometheus<br>&nbsp;&nbsp;port: web |
+| serviceMonitor.endpoints | Array of endpoints to be scraped by prometheus |   - interval: 5s<br>&nbsp;&nbsp;path: /actuator/prometheus<br>&nbsp;&nbsp;port: http |

--- a/application/templates/service.yaml
+++ b/application/templates/service.yaml
@@ -8,9 +8,6 @@ metadata:
 {{- if .Values.service.additionalLabels }}
 {{ toYaml .Values.service.additionalLabels | indent 4 }}
 {{- end }}
-{{- if .Values.serviceMonitor.enabled }}
-    {{ .Values.serviceMonitor.jobLabel }}: {{ template "application.name" . }}
-{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/application/templates/servicemonitor.yaml
+++ b/application/templates/servicemonitor.yaml
@@ -16,11 +16,9 @@ metadata:
 {{- end }}
   name: {{ template "application.name" . }}-svc-monitor
 spec:
-{{- $jobLabel := .Values.serviceMonitor.jobLabel }}
-  jobLabel: {{ $jobLabel }}
   selector:
     matchLabels:
-      {{ $jobLabel }}: {{ template "application.name" . }}
+      app: {{ template "application.name" . }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -1,5 +1,5 @@
 # Name of the application.
-applicationName: "application"
+applicationName: "gac-eyeshare-integration"
 
 # These labels will be added on all resources, and you can add additional labels from below on individual resource
 labels:
@@ -348,9 +348,6 @@ serviceMonitor:
   annotations:
     # key: value
 
-  # Job Label used for application selector
-  jobLabel: k8s-app
-  
   # List of the endpoints of service from which prometheus will scrape data
   endpoints:
   - interval: 5s

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -1,5 +1,5 @@
 # Name of the application.
-applicationName: "gac-eyeshare-integration"
+applicationName: "application"
 
 # These labels will be added on all resources, and you can add additional labels from below on individual resource
 labels:


### PR DESCRIPTION
Don't need unnecessary labels. use already defined label `app` 