### PR TITLE
Add volume mounts persistence and fix labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ To uninstall the chart:
 | applicationName | Name of the application | `application` |
 | labels.group | Label to define application group | `com.stakater.platform` |
 | labels.team | Label to define team | `stakater` |
-| deployment.strategy.type | Strategy for updating deployments |`RollingUpdate`|
-| deployment.strategy.rollingUpdate | Rolling update configuration | rollingUpdate:<br>&nbsp;&nbsp;maxSurge: 25%<br>&nbsp;&nbsp;maxUnavailable: 25% |
+| deployment.strategy | Strategy for updating deployments |`RollingUpdate`|
 | deployment.reloadOnChange| Reload deployment if configMap/secret mounted are updated | `true` |
 | deployment.nodeSelector | Select node to deploy this application | `{}` |
 | deployment.initContainers | Init containers which runs before the app container | `[]` |
 | deployment.additionalLabels | Additional labels for Deployment | `{}` |
-| deployment.podLables | Additional label added on pod which is used in Service's Label Selector | `app: application-name` |
+| deployment.podLables | Additional label added on pod which is used in Service's Label Selector | {} |
 | deployment.annotations | Annotations on deployments | `{}` |
 | deployment.additionalPodAnnotation  | Additional Pod Annotations added on pod created by this Deployment | `{}` |
 | deployment.fluentdConfigAnnotations | Annotations for fluentd Configurations | `{}` |
@@ -60,6 +59,8 @@ To uninstall the chart:
 | deployment.additionalContainers | Add additional containers besides init and app containers | `[]` |
 | deployment.securityContext | Security Context for the pod | `{}` |
 | persistence.enabled | Enable persistence | `false` |
+| persistence.mountPVC | Whether to mount the created PVC to the deployment | `false` |
+| persistence.mountPath | If `persistence.mountPVC` is set, so where to mount the volume in the deployment | `/` |
 | persistence.accessMode | Access mode for volume | `ReadWriteOnce` |
 | persistence.storageClass | StorageClass of the volume  | `-` |
 | persistence.additionalLabels | Additional labels for persistent volume | `{}` |

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -16,6 +16,9 @@ appVersion: "{{ .Values.deployment.image.tag }}"
 {{- end -}}
 
 {{- define "application.labels.chart" -}}
+group: {{ .Values.labels.group }}
+provider: stakater
+team: {{ .Values.labels.team }}
 chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 release: {{ .Release.Name | quote }}
 heritage: {{ .Release.Service | quote }}

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -8,9 +8,6 @@ Define the name of the chart/application.
 
 {{- define "application.labels.selector" -}}
 app: {{ template "application.name" . }}
-group: {{ .Values.labels.group }}
-provider: stakater
-team: {{ .Values.labels.team }}
 {{- end -}}
 
 {{- define "application.labels.stakater" -}}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
-{{ include "application.labels.selector" . | indent 6 }}
+{{ include "application.labels.stakater" . | indent 6 }}
   {{- if .Values.deployment.strategy }}
   strategy:
 {{ toYaml .Values.deployment.strategy | indent 4 }}
@@ -31,7 +31,6 @@ spec:
     metadata:
       labels:
 {{ include "application.labels.stakater" . | indent 8 }}
-{{ include "application.labels.chart" . | indent 8 }}
 {{- if .Values.deployment.podLabels }}
 {{ toYaml .Values.deployment.podLabels | indent 8 }}
 {{- end }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -113,10 +113,16 @@ spec:
           httpGet:
             path: {{ .Values.deployment.probes.readinessProbe.httpGet.path }}
             port: {{ .Values.deployment.probes.readinessProbe.httpGet.port }}
-        {{- if .Values.deployment.volumeMounts }}
+      {{- if or (.Values.deployment.volumeMounts) (and (eq .Values.persistence.enabled true) (eq .Values.persistence.mountPVC true) )}} 
         volumeMounts:
+        {{- if (eq .Values.persistence.mountPVC true) }}
+        - mountPath: {{ .Values.persistence.mountPath }}
+          name: {{ template "application.name" . }}-data
+        {{- end }}
+        {{- if .Values.deployment.volumeMounts }}
 {{ toYaml .Values.deployment.volumeMounts | indent 10 }}
         {{- end }}
+      {{- end }}
         resources:
           limits:
             memory: {{ .Values.deployment.resources.limits.memory }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -119,7 +119,7 @@ spec:
           name: {{ template "application.name" . }}-data
         {{- end }}
         {{- if .Values.deployment.volumeMounts }}
-{{ toYaml .Values.deployment.volumeMounts | indent 10 }}
+{{ toYaml .Values.deployment.volumeMounts | indent 8 }}
         {{- end }}
       {{- end }}
         resources:
@@ -144,7 +144,7 @@ spec:
           claimName: {{ template "application.name" . }}-data
         {{- end }}
         {{- if .Values.deployment.volumes }}
-{{ toYaml .Values.deployment.volumes | indent 8 }}
+{{ toYaml .Values.deployment.volumes | indent 6 }}
         {{- end }}
       {{- end }}  
       {{- if .Values.rbac.serviceAccount.name }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -137,10 +137,17 @@ spec:
       securityContext:      
 {{ toYaml .Values.deployment.securityContext | indent 8 }}
           {{- end }}
-      {{- if .Values.deployment.volumes }}
+      {{- if or (.Values.deployment.volumes) (and (eq .Values.persistence.enabled true) (eq .Values.persistence.mountPVC true) )}} 
       volumes:
+        {{- if (eq .Values.persistence.mountPVC true) }}
+      - name: {{ template "application.name" . }}-data
+        persistentVolumeClaim:
+          claimName: {{ template "application.name" . }}-data
+        {{- end }}
+        {{- if .Values.deployment.volumes }}
 {{ toYaml .Values.deployment.volumes | indent 8 }}
-        {{- end }}  
+        {{- end }}
+      {{- end }}  
       {{- if .Values.rbac.serviceAccount.name }}
       serviceAccountName: {{ .Values.rbac.serviceAccount.name }}
         {{- else }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
-{{ include "application.labels.stakater" . | indent 6 }}
+{{ include "application.labels.selector" . | indent 6 }}
   {{- if .Values.deployment.strategy }}
   strategy:
 {{ toYaml .Values.deployment.strategy | indent 4 }}
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       labels:
-{{ include "application.labels.stakater" . | indent 8 }}
+{{ include "application.labels.selector" . | indent 8 }}
 {{- if .Values.deployment.podLabels }}
 {{ toYaml .Values.deployment.podLabels | indent 8 }}
 {{- end }}

--- a/application/templates/service.yaml
+++ b/application/templates/service.yaml
@@ -15,7 +15,7 @@ metadata:
   name: {{ template "application.name" . }}
 spec:
   selector:
-{{ include "application.labels.stakater" . | indent 4 }}
+{{ include "application.labels.selector" . | indent 4 }}
 {{- if .Values.deployment.podLabels }}
 {{ toYaml .Values.deployment.podLabels | indent 4 }}
 {{- end }}

--- a/application/templates/service.yaml
+++ b/application/templates/service.yaml
@@ -15,7 +15,10 @@ metadata:
   name: {{ template "application.name" . }}
 spec:
   selector:
+{{ include "application.labels.stakater" . | indent 4 }}
+{{- if .Values.deployment.podLabels }}
 {{ toYaml .Values.deployment.podLabels | indent 4 }}
+{{- end }}
   ports:
 {{ toYaml .Values.service.ports | indent 4 }}
 {{- end }}

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -36,7 +36,7 @@ deployment:
   
   # Additional label added on pod which is used in Service's Label Selector
   podLabels: 
-    app: application-name
+    # env: prod
 
   # Annotations on deployments
   annotations:

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -12,9 +12,9 @@ deployment:
   # You can change type to `Recreate` or can uncomment `rollingUpdate` specification and adjust them to your usage.
   strategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
+    # rollingUpdate:
+    #   maxSurge: 25%
+    #   maxUnavailable: 25%
   
   # Reload deployment if configMap/secret updates
   reloadOnChange: true

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -149,6 +149,8 @@ deployment:
 # Add Storage volumes to the pods
 persistence:
   enabled: false
+  mountPVC: false
+  mountPath: "/"
   accessMode: ReadWriteOnce
   ## If defined, storageClass: <storageClass>
   ## If set to "-", storageClass: "", which disables dynamic provisioning


### PR DESCRIPTION
This PR
- removes default values for rolling update as cant set strategy to recreate due to it
- changes pod label as application label is part of chart now
- adds values for mount pvc and path in case persistence is true