### PR TITLE
add additional config for endpoint monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ To uninstall the chart:
 | endpointMonitor.enabled | Enable endpointMonitor for IMC (https://github.com/stakater/IngressMonitorController) | `false` |
 | endpointMonitor.additionalLabels | Labels for endpointMonitor | `{}` |
 | endpointMonitor.annotations | Annotations for endpointMonitor | `{}` |
+| endpointMonitor.additionalConfig | Additional Config for endpointMonitor | `{}` |

--- a/application/templates/endpointmonitor.yaml
+++ b/application/templates/endpointmonitor.yaml
@@ -26,5 +26,5 @@ spec:
       name:  {{ template "application.name" . }}
 {{- end }}
 {{- if .Values.endpointMonitor.additionalConfig }}
-{{ toYaml .Values.endpointMonitor.additionalConfig | indent 4 }}
+{{ toYaml .Values.endpointMonitor.additionalConfig | indent 2 }}
 {{- end }}

--- a/application/templates/endpointmonitor.yaml
+++ b/application/templates/endpointmonitor.yaml
@@ -25,3 +25,6 @@ spec:
 {{- end }}
       name:  {{ template "application.name" . }}
 {{- end }}
+{{- if .Values.endpointMonitor.additionalConfig }}
+{{ toYaml .Values.endpointMonitor.additionalConfig | indent 4 }}
+{{- end }}


### PR DESCRIPTION
So, additional config shld present this part

```
  uptimeRobotConfig:
    alertContacts: "6786045_0_0"

```
in

```
apiVersion: endpointmonitor.stakater.com/v1alpha1
kind: EndpointMonitor
metadata:
  name: sonarqube
  namespace: cluster-enento-devtest
spec:
  forceHtpps: true
  url: https://sonarqube-openshift-stakater-sonarqube.apps.devtest.adx45rg.kube.cloud/
  uptimeRobotConfig:
    alertContacts: "6786045_0_0"
```