### PR TITLE
Fix typo in Deployment templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,8 @@ To disable liveness or readiness probe, set value of `enabled:` to `false`.
 
 All notable changes to this project will be documented here
 
+## v1.1.13
+- Fix: fix templating error in `Deployment.envFrom.secretRef`, fixes an `error converting YAML to JSON` error when `application.deployment.envfrom[].name` is set.
 ## v1.1.12
 - Fix: add `probes` key back to deployment
 ## v1.1.11

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
         {{- if (eq .type "secret") }}
         - secretRef:
             {{- if .name }}
-            name: { include "application.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
+            name: {{ include "application.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
             {{- else if .nameSuffix }}
             name: {{ template "application.name" $ }}-{{ include "application.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
             {{- else }}


### PR DESCRIPTION
Fixes the templating for Deployment.envFrom.secretRef
Fixes the error `error converting YAML to JSON: yaml` [...] `did not find expected key`