### PR TITLE
Update generate tag version to 1.36.0

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,7 +34,7 @@ jobs:
     # Generate tag for chart without "v" prefix
     - name: Generate Tag
       id: generate_tag
-      uses: anothrNick/github-tag-action@1.26.0
+      uses: anothrNick/github-tag-action@1.36.0
       env:
         GITHUB_TOKEN: ${{ secrets.STAKATER_GITHUB_TOKEN }}
         WITH_V: false
@@ -93,7 +93,7 @@ jobs:
         github_token: ${{ secrets.STAKATER_GITHUB_TOKEN }}
 
     - name: Push Latest Tag
-      uses: anothrNick/github-tag-action@1.26.0
+      uses: anothrNick/github-tag-action@1.36.0
       env:
         GITHUB_TOKEN: ${{ secrets.STAKATER_GITHUB_TOKEN }}
         WITH_V: true


### PR DESCRIPTION
Updated generate tag version from 1.26.0 to 1.36.0 due security vulnerability