### PR TITLE
Add support for Deployment startup probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,15 @@ To uninstall the chart:
 ##### Startup Probe
 StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully.
 
-| Name                     | Description                                                                                  | Value           |
-| ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
-| deployment.startupProbe.enabled | Enabled startup probe                                                                  | true       |
-| deployment.startupProbe.failureThreshold | When a probe fails, Kubernetes will try failureThreshold times before giving up.                                                                  | 3      |
-| deployment.startupProbe.periodSeconds | Perform probe  everytime after specified periodSeconds                                                                  | 10       |
-| deployment.startupProbe.successThreshold | Minimum consecutive successes for the probe to be considered successful after having failed.                                                                  | 1       |
-| deployment.startupProbe.timeoutSeconds | Number of seconds after which the probe times out.                                                                  | 1       |
-| deployment.startupProbe.httpGet | Describes an action based on HTTP Get requests                                                                  |   path: '/path' port: 8080     |
-| deployment.startupProbe.exec | Kubelet executes the specified command to perform the probe                                                                  |   {}   |
+| Name                     | Description                                                                                 | Value                  |
+| ------------------------ |---------------------------------------------------------------------------------------------|------------------------|
+| deployment.startupProbe.enabled | Enabled startup probe                                                                       | false                  |
+| deployment.startupProbe.failureThreshold | When a probe fails, Kubernetes will try failureThreshold times before giving up.    | 30              |
+| deployment.startupProbe.periodSeconds | Perform probe  everytime after specified periodSeconds                                | 10                     |
+| deployment.startupProbe.successThreshold | Minimum consecutive successes for the probe to be considered successful after having failed. |                        |
+| deployment.startupProbe.timeoutSeconds | Number of seconds after which the probe times out.                                    |                        |
+| deployment.startupProbe.httpGet | Describes an action based on HTTP Get requests                                              | path: '/path' port: 8080 |
+| deployment.startupProbe.exec | Kubelet executes the specified command to perform the probe                                 | {}          |
 
 
 ##### Readiness Probe

--- a/README.md
+++ b/README.md
@@ -100,7 +100,22 @@ To uninstall the chart:
 
 #### Deployment Probes Paramaters
 
+##### Startup Probe
+StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully.
+
+| Name                     | Description                                                                                  | Value           |
+| ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
+| deployment.startupProbe.enabled | Enabled startup probe                                                                  | true       |
+| deployment.startupProbe.failureThreshold | When a probe fails, Kubernetes will try failureThreshold times before giving up.                                                                  | 3      |
+| deployment.startupProbe.periodSeconds | Perform probe  everytime after specified periodSeconds                                                                  | 10       |
+| deployment.startupProbe.successThreshold | Minimum consecutive successes for the probe to be considered successful after having failed.                                                                  | 1       |
+| deployment.startupProbe.timeoutSeconds | Number of seconds after which the probe times out.                                                                  | 1       |
+| deployment.startupProbe.httpGet | Describes an action based on HTTP Get requests                                                                  |   path: '/path' port: 8080     |
+| deployment.startupProbe.exec | Kubelet executes the specified command to perform the probe                                                                  |   {}   |
+
+
 ##### Readiness Probe
+Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails.
 
 | Name                     | Description                                                                                  | Value           |
 | ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
@@ -114,6 +129,7 @@ To uninstall the chart:
 | deployment.readinessProbe.exec | Kubelet executes the specified command to perform the probe                                                                  |   {}   |
 
 ##### Liveness Probe
+Periodic probe of container liveness. Container will be restarted if the probe fails.
 
 | Name                     | Description                                                                                  | Value           |
 | ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -164,6 +164,21 @@ spec:
 {{ include "application.tplvalues.render" ( dict "value" $value "context" $ ) | indent 10 }}
         {{- end }}
         {{- end }}
+        {{- if .Values.deployment.startupProbe.enabled }}
+        startupProbe:
+          failureThreshold: {{ .Values.deployment.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.deployment.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.deployment.startupProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.deployment.startupProbe.timeoutSeconds }}
+          initialDelaySeconds: {{ .Values.deployment.startupProbe.initialDelaySeconds }}
+          {{- if .Values.deployment.startupProbe.exec }}
+          exec:
+            {{- toYaml .Values.deployment.startupProbe.exec | nindent 12 }}
+          {{- else if .Values.deployment.startupProbe.httpGet }}
+          httpGet:
+            {{- toYaml .Values.deployment.startupProbe.httpGet | nindent 12 }}
+          {{- end }}
+        {{- end }}
         {{- if .Values.deployment.livenessProbe.enabled }} 
         livenessProbe:
           failureThreshold: {{ .Values.deployment.livenessProbe.failureThreshold }}

--- a/application/values-test.yaml
+++ b/application/values-test.yaml
@@ -135,7 +135,16 @@ deployment:
     tag: v1.0.0
     pullPolicy: IfNotPresent
 
-  # Readiness and Liveness probes
+  # Startup, Readiness and Liveness probes
+  startupProbe:
+    enabled: false
+    failureThreshold: 30
+    periodSeconds: 10
+    httpGet:
+      path: '/path'
+      port: 8080
+    exec: { }
+
   readinessProbe:
     enabled: true
     failureThreshold: 3
@@ -147,6 +156,7 @@ deployment:
       command:
         - cat
         - tmp/healthy
+
   livenessProbe:
     enabled: true
     failureThreshold: 3

--- a/application/values-test.yaml
+++ b/application/values-test.yaml
@@ -137,7 +137,7 @@ deployment:
 
   # Startup, Readiness and Liveness probes
   startupProbe:
-    enabled: false
+    enabled: true
     failureThreshold: 30
     periodSeconds: 10
     httpGet:

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -168,7 +168,16 @@ deployment:
     # options:
     # - name: ndots
     #   value: '1'
-  # Readiness and Liveness probes
+  # Startup, Readiness and Liveness probes
+  startupProbe:
+    enabled: false
+    failureThreshold: 30
+    periodSeconds: 10
+    httpGet:
+      path: '/path'
+      port: 8080
+    exec: {}
+
   readinessProbe:
     enabled: true
     failureThreshold: 3


### PR DESCRIPTION
This probe is good for slow starting applications instead of relying om initialDelaySeconds that will make the pod start slower then necessar.

Docs: 
StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes